### PR TITLE
Alpine Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # swiss-army-knife
-Container that contains (haha) lots of tools we use on a daily basis, with SSH daemon
+Container that contains (haha) lots of tools we use on a frequently. Is normally Ubuntu-based image, but Alpine could be used with some caveats
 
 ## Quicky and Dirty
 ```
@@ -12,23 +12,13 @@ ssh root@localhost -p $(podman port swiss-army-knife | awk -F\: '{print $2}')
 Building it local
 ```
 podman build -t swiss-army-knife .
+
+Run the container
+```
 podman run -d -P --name swiss-army-knife localhost/swiss-army-knife:latest
 ```
 
-Get the port
-```
-podman port swiss-army-knife
-22/tcp -> 0.0.0.0:44563
-```
-
-SSH in
-```
-ssh root@localhost -p 44563
-Last login: Wed Sep  2 10:49:55 2020 from 127.0.0.1
-root@ef8ce90c0ea5:~# 
-```
-
-Stop conatiner
+Stop container
 ```
 podman stop swiss-army-knife
 podman rm swiss-army-knife
@@ -48,20 +38,7 @@ kubectl run -it --rm swiss-army-knife --image=lsdopen/swiss-army-knife:latest --
 
 ```
 kubectl create deployment swiss-army-knife --image=lsdopen/swiss-army-knife:latest
-kubectl create service nodeport swiss-army-knife --tcp=22:22
-```
-
-Determine the NodePort
-```
-kubectl get svc swiss-army-knife
-
-NAME               TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
-swiss-army-knife   NodePort   172.31.107.24   <none>        22:30316/TCP   99s
-```
-
-SSH onto any Kubernetes Node on that port
-```
-ssh root@worker-node-01 -p 30316
+kubectl expose deployment swiss-army-knife
 ```
 
 ### Declarative
@@ -98,13 +75,12 @@ metadata:
     app: swiss-army-knife
   name: swiss-army-knife
 spec:
+  clusterIP: {}
   ports:
-  - name: 22-22
-    nodePort: 30316
-    port: 22
+  - name: "8080"
     protocol: TCP
-    targetPort: 22
+    targetPort: 8080
   selector:
     app: swiss-army-knife
-  type: NodePort
+  type: ClusterIP
 ```

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine
+
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+RUN apk fix && \
+    apk --no-cache --update add \ 
+    bash \
+    less \
+    wget \
+    ca-certificates \
+    curl \
+    vim \
+    git \
+    tar \
+    unzip \
+    nmap-ncat \
+    tcptraceroute \
+    traceroute \
+    bind-tools \
+    p7zip \
+    rsync \
+    httpie \
+    jq \
+    iputils-ping \
+    iputils \
+ && rm -rf /var/cache \
+ && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+ && install -o root -g root -m 0755 kubectl /usr/bin/kubectl \
+ && rm ./kubectl
+
+
+## Webify. Thanks Cron.weekly
+## https://github.com/beefsack/webify/
+# This assumes below that you already built webify
+# and just copies the binary into the image
+COPY ./webify /usr/local/bin/webify
+
+EXPOSE 8080
+ENTRYPOINT ["sleep", "infinity"]
+


### PR DESCRIPTION
Updated README.md to remove `ssh` references.  Added alpine references

Added: `./alpine/Dockerfile`

Base image size comparisons

```
REPOSITORY                        TAG                IMAGE ID       CREATED          SIZE
swiss-army-knife   20240405c-ubuntu   a9c6e9fbadce   18 minutes ago   304MB
swiss-army-knife   20240405b-alpine   6794f26701c2   26 minutes ago   197MB
ubuntu                            22.04              3db8720ecbf5   7 weeks ago      77.9MB
alpine                            latest             05455a08881e   2 months ago     7.38MB
```

Alpine's _`git`_ package doesn't pull in _`perl`_ package dependencies, which shaves around 50MB.